### PR TITLE
Remove config mounts from docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,9 +45,6 @@ services:
     volumes:
       - prometheus-data:/prometheus
       - prometheus-rules:/etc/prometheus/rules
-    configs:
-      - source: prometheus-config
-        target: /etc/prometheus/prometheus.yml
     command:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.path=/prometheus
@@ -111,29 +108,6 @@ services:
       - no-new-privileges:true
     volumes:
       - grafana-data:/var/lib/grafana
-    configs:
-      - source: grafana-datasource
-        target: /etc/grafana/provisioning/datasources/prometheus.yml
-      - source: grafana-dashboard-provider
-        target: /etc/grafana/provisioning/dashboards/provider.yml
-      - source: grafana-dashboard-server
-        target: /etc/grafana/provisioning/dashboards/server.json
-      - source: grafana-dashboard-gpu
-        target: /etc/grafana/provisioning/dashboards/gpu.json
-      - source: grafana-dashboard-plex-streaming
-        target: /etc/grafana/provisioning/dashboards/plex-streaming.json
-      - source: grafana-dashboard-storage
-        target: /etc/grafana/provisioning/dashboards/storage.json
-      - source: grafana-dashboard-thermals
-        target: /etc/grafana/provisioning/dashboards/thermals.json
-      - source: grafana-dashboard-container
-        target: /etc/grafana/provisioning/dashboards/container.json
-      - source: grafana-dashboard-media-server
-        target: /etc/grafana/provisioning/dashboards/media-server.json
-      - source: grafana-dashboard-media-server-legacy
-        target: /etc/grafana/provisioning/dashboards/Media Server.json
-      - source: grafana-dashboard-plex
-        target: /etc/grafana/provisioning/dashboards/plex.json
 
   cadvisor:
     image: gcr.io/cadvisor/cadvisor:latest
@@ -159,28 +133,3 @@ volumes:
   prometheus-rules:
   grafana-data:
 
-configs:
-  prometheus-config:
-    file: ./prometheus/config/prometheus.yml
-  grafana-datasource:
-    file: ./grafana/provisioning/datasources/prometheus.yml
-  grafana-dashboard-provider:
-    file: ./grafana/provisioning/dashboards/provider.yml
-  grafana-dashboard-server:
-    file: ./grafana/provisioning/dashboards/server.json
-  grafana-dashboard-gpu:
-    file: ./grafana/provisioning/dashboards/gpu.json
-  grafana-dashboard-plex-streaming:
-    file: ./grafana/provisioning/dashboards/plex-streaming.json
-  grafana-dashboard-storage:
-    file: ./grafana/provisioning/dashboards/storage.json
-  grafana-dashboard-thermals:
-    file: ./grafana/provisioning/dashboards/thermals.json
-  grafana-dashboard-container:
-    file: ./grafana/provisioning/dashboards/container.json
-  grafana-dashboard-media-server:
-    file: ./grafana/provisioning/dashboards/media-server.json
-  grafana-dashboard-media-server-legacy:
-    file: './grafana/provisioning/dashboards/Media Server.json'
-  grafana-dashboard-plex:
-    file: ./grafana/provisioning/dashboards/plex.json


### PR DESCRIPTION
## Summary
- remove the config mounts from the Prometheus and Grafana services
- drop the associated config definitions from the docker compose file

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9473188588327b89d33c649313cfe