### PR TITLE
Randomize external ports in compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     env_file:
       - ./dozzle/.env
     ports:
-      - 8080:8080/tcp
+      - 50647:8080/tcp
     security_opt:
       - no-new-privileges:true
     volumes:
@@ -36,7 +36,7 @@ services:
       - ./prometheus/.env
     user: "1000:1000"
     ports:
-      - 9090:9090/tcp
+      - 50712:9090/tcp
     security_opt:
       - no-new-privileges:true
     volumes:
@@ -100,7 +100,7 @@ services:
       - ./grafana/.env
     user: "1000:1000"
     ports:
-      - 3000:3000/tcp
+      - 50983:3000/tcp
     security_opt:
       - no-new-privileges:true
     volumes:


### PR DESCRIPTION
## Summary
- update docker-compose external port mappings to use random values in the 50000 range for Dozzle, Prometheus, and Grafana

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d94a0b1dd48327af8cef3650dc9171